### PR TITLE
Opening of header links in new tab functionality added

### DIFF
--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -1,7 +1,7 @@
-import React, {useState} from "react";
-import {GiHamburgerMenu} from "react-icons/gi";
+import React, { useState } from "react";
+import { GiHamburgerMenu } from "react-icons/gi";
 import './Header.css';
-import {useLocation} from "react-router-dom";
+import { useLocation } from "react-router-dom";
 
 
 const Header = () => {
@@ -23,13 +23,13 @@ const Header = () => {
                             <a href="/" className={splitLocation[1] === "" ? "active" : " "}>Home</a>
                         </li>
                         <li>
-                            <a href="/notes" className={splitLocation[1] === "notes" ? "active" : " "}>Notes</a>
+                            <a target={'_blank'} href="/notes" className={splitLocation[1] === "notes" ? "active" : " "}>Notes</a>
                         </li>
                         <li>
-                            <a href="/PYQs" className={splitLocation[1] === "PYQs" ? "active" : " "}>PYQs</a>
+                            <a target={'_blank'} href="/PYQs" className={splitLocation[1] === "PYQs" ? "active" : " "}>PYQs</a>
                         </li>
                         <li>
-                            <a href="/feedbacks" className={splitLocation[1] === "feedbacks" ? "active" : " "}>Feedbacks</a>
+                            <a target={'_blank'} href="/feedbacks" className={splitLocation[1] === "feedbacks" ? "active" : " "}>Feedbacks</a>
                         </li>
                     </ul>
 
@@ -38,7 +38,7 @@ const Header = () => {
                 <div className="drop-down-nav">
                     <div className="hamburger-menu">
                         <a href="#" onClick={() => setShowNavItems(!showNavItems)}>
-                            <GiHamburgerMenu style={{color: "white"}}/>
+                            <GiHamburgerMenu style={{ color: "white" }} />
                         </a>
                     </div>
                 </div>


### PR DESCRIPTION
## Purpose ✨
Reference to issue #15 :
To add page redirection to a new tab when a link of the header is clicked.

## Details 📝

In this PR, the functionality to open links in a new tab of the header links is added. For that following changes have been made:
- Added `target = {"_blank"}` in `<a>` tag of the links 

## Dependencies 🔗

None

## Future Improvements 🔭

None

## Mentions 👀

@AnshumanDhiman @Ananyaiitbhilai 

## Screenshots of relevant screens 📸

None

## Developer's checklist 📃
- [x] Followed the [coding guidelines](https://google.github.io/styleguide/jsguide.html).
- [x] Properly commented the code.
- [x] No print statements in the code. <!-- If you have some print statements in the code then mention the reason here. -->
- [x] All the functionalities are working properly.
- [x] Changes made are not breaking any other part of the project.
- [x] No UI/UX issues are present.
- [x] Relevant screenshots are added in the PR. - Not needed as no UI/UX changes are there.
- [x] Followed the PR guidelines