### PR TITLE
Made Add Note Modal Container Resposive

### DIFF
--- a/src/components/Common/ModalContainer.tsx
+++ b/src/components/Common/ModalContainer.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, FC, SetStateAction, useRef } from 'react'
+import { Dispatch, FC, SetStateAction, useEffect } from 'react'
 
 export const ModalContainer: FC<{
     showModal: boolean
@@ -6,14 +6,27 @@ export const ModalContainer: FC<{
     header: string
     setShowModal: Dispatch<SetStateAction<boolean>>
 }> = ({ children, showModal, header, setShowModal }) => {
+    // Lock the background scroll when the modal is open
+    useEffect(() => {
+        if (showModal) {
+            document.body.style.overflow = 'hidden'; // Disable scroll on background
+        } else {
+            document.body.style.overflow = ''; // Re-enable scroll
+        }
+
+        return () => {
+            document.body.style.overflow = ''; // Cleanup on unmount
+        }
+    }, [showModal]);
+
     return (
         <div
             className={`${
                 !showModal && 'hidden'
             } flex justify-center items-center fixed top-0 left-0 right-0 z-50 w-full bg-black/50 overflow-x-hidden overflow-y-auto h-full`}
         >
-            <div className="relative w-full h-full mt-16 flex flex-col justify-center max-w-2xl md:h-auto">
-                <div className="relative bg-white rounded-lg shadow">
+            <div className="relative w-full h-full mt-16 flex flex-col justify-center max-w-lg sm:max-w-md md:max-w-2xl lg:max-w-4xl xl:max-w-5xl md:h-auto px-4 sm:px-6 lg:px-8 overflow-y-auto mb-12">
+                <div className="relative bg-white rounded-lg shadow-lg max-h-full overflow-y-auto">
                     <div className="flex items-start justify-between p-4 border-b rounded-t">
                         <h3 className="text-xl font-semibold text-gray-900">
                             {header}
@@ -39,7 +52,10 @@ export const ModalContainer: FC<{
                             <span className="sr-only">Close modal</span>
                         </button>
                     </div>
-                    {children}
+                    {/* Make the content scrollable */}
+                    <div className="overflow-y-auto max-h-[60vh] sm:max-h-[70vh] md:max-h-[80vh] lg:max-h-[90vh]">
+                        {children}
+                    </div>
                 </div>
             </div>
         </div>

--- a/src/components/Common/ModalContainer.tsx
+++ b/src/components/Common/ModalContainer.tsx
@@ -6,16 +6,15 @@ export const ModalContainer: FC<{
     header: string
     setShowModal: Dispatch<SetStateAction<boolean>>
 }> = ({ children, showModal, header, setShowModal }) => {
-    // Lock the background scroll when the modal is open
     useEffect(() => {
         if (showModal) {
-            document.body.style.overflow = 'hidden'; // Disable scroll on background
+            document.body.style.overflow = 'hidden'; 
         } else {
-            document.body.style.overflow = ''; // Re-enable scroll
+            document.body.style.overflow = ''; 
         }
 
         return () => {
-            document.body.style.overflow = ''; // Cleanup on unmount
+            document.body.style.overflow = ''; 
         }
     }, [showModal]);
 
@@ -52,7 +51,6 @@ export const ModalContainer: FC<{
                             <span className="sr-only">Close modal</span>
                         </button>
                     </div>
-                    {/* Make the content scrollable */}
                     <div className="overflow-y-auto max-h-[60vh] sm:max-h-[70vh] md:max-h-[80vh] lg:max-h-[90vh]">
                         {children}
                     </div>


### PR DESCRIPTION
This PR addresses the following updates for the modals in the "Add Note" and "Add PYQ" sections:

**Responsive Modal Design:**

Made the modal containers for "Add Note" and "Add PYQ" responsive to ensure they fit properly across different screen sizes.
Implemented CSS adjustments using Tailwind classes to control modal width and ensure they are not too wide on smaller devices. This enhances the user experience, especially on mobile devices.

**Background Scroll Prevention:**

Added logic to prevent scrolling of the background when either of the modals is open. This ensures that users focus on the modal content without the distraction of scrolling the background.
Implemented this feature using React's useEffect hook to toggle the body’s overflow property based on the modal’s visibility.

**Improved Modal Content Overflow:**

Made the modal content scrollable when necessary, restricting the height of modal content to a percentage of the screen height (vh) to avoid cutting off long content while keeping the overall modal within view.
Added margin at the bottom to prevent the modal from sticking to the bottom of the screen, ensuring a better user experience.